### PR TITLE
add import dashboard flow

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,4 +1,6 @@
 <script>
+  import ModelUsageChart from "./lib/ModelUsageChart.svelte";
+
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
 
   let selectedFile = null;
@@ -7,6 +9,7 @@
   let successMessage = "";
   let importData = null;
   let globalStatsEntries = [];
+  let modelStats = {};
 
   const GLOBAL_STAT_LABELS = {
     total_convos: "total conversations",
@@ -61,6 +64,7 @@
   $: globalStatsEntries = importData?.global_stats
     ? Object.entries(importData.global_stats)
     : [];
+  $: modelStats = importData?.model_stats ?? {};
 </script>
 
 <main class="mx-auto min-h-screen max-w-5xl p-6">
@@ -116,5 +120,11 @@
         {/each}
       </div>
     </section>
+  {/if}
+
+  {#if Object.keys(modelStats).length > 0}
+    <div class="mt-6">
+      <ModelUsageChart {modelStats} />
+    </div>
   {/if}
 </main>

--- a/frontend/src/lib/ModelUsageChart.svelte
+++ b/frontend/src/lib/ModelUsageChart.svelte
@@ -1,0 +1,93 @@
+<script>
+  import { onDestroy } from "svelte";
+  import {
+    BarController,
+    BarElement,
+    CategoryScale,
+    Chart,
+    LinearScale,
+    Tooltip,
+  } from "chart.js";
+
+  Chart.register(BarController, BarElement, CategoryScale, LinearScale, Tooltip);
+
+  export let modelStats = {};
+
+  let canvas = null;
+  let chart = null;
+  let sortedEntries = [];
+
+  $: sortedEntries = Object.entries(modelStats ?? {}).sort((first, second) => second[1] - first[1]);
+
+  $: if (canvas) {
+    renderChart();
+  }
+
+  function renderChart() {
+    if (chart) {
+      chart.destroy();
+      chart = null;
+    }
+
+    if (!sortedEntries.length) {
+      return;
+    }
+
+    chart = new Chart(canvas, {
+      type: "bar",
+      data: {
+        labels: sortedEntries.map(([model]) => model),
+        datasets: [
+          {
+            label: "messages",
+            data: sortedEntries.map(([, count]) => count),
+            backgroundColor: "rgba(56, 189, 248, 0.85)",
+            borderRadius: 6,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          tooltip: {
+            displayColors: false,
+          },
+        },
+        scales: {
+          y: {
+            beginAtZero: true,
+            ticks: {
+              precision: 0,
+            },
+            grid: {
+              color: "rgba(148, 163, 184, 0.15)",
+            },
+          },
+          x: {
+            grid: {
+              display: false,
+            },
+          },
+        },
+      },
+    });
+  }
+
+  onDestroy(() => {
+    if (chart) {
+      chart.destroy();
+    }
+  });
+</script>
+
+<section class="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+  <h2 class="text-lg font-semibold text-slate-100">model usage</h2>
+  <div class="mt-4 h-72">
+    {#if sortedEntries.length > 0}
+      <canvas bind:this={canvas}></canvas>
+    {:else}
+      <p class="text-sm text-slate-400">no model usage found in this export.</p>
+    {/if}
+  </div>
+</section>


### PR DESCRIPTION
## what
- adds import form state and api request flow in the dashboard page
- updates the page to show global stats cards after a successful import
- keeps model usage in a dedicated chart component with descending sort

## why
- needed so issue #2 has a working end-to-end import dashboard
- helps keep frontend behavior easy to follow with small components

## checks
- ran   `cd frontend && npm test -- --run`
- result: pass (1 test)
- ran   `cd frontend && npm run build`
- result: pass

## issue
- closes #2
- refs #2
